### PR TITLE
Handling the path issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,4 @@ pipe/config/conf_rubicon.json
 pipe/config/conf_hydra.json
 conf_rubicon.json
 conf_hydra.json
+*.DS_Store

--- a/pipe/__init__.py
+++ b/pipe/__init__.py
@@ -29,3 +29,4 @@ from .reduce import (
 from .pipe_control import PipeControl
 from .pipe_param import PipeParam
 from .pipe_statistics import mad, sigma_clip
+from .config import conf

--- a/pipe/config/pipeconf.py
+++ b/pipe/config/pipeconf.py
@@ -2,14 +2,31 @@ import json
 import os
 import astropy.config as astropyconfig
 
-
 def cache_dir():
     return astropyconfig.get_cache_dir()
 
 
-def get_conf_paths():
+def get_conf_paths(overwrite=False):
     # Get configuration information from setup.cfg
     conf_path = os.path.join(os.path.dirname(__file__), 'conf.json')
+    
+    if (not os.path.isfile(conf_path))|(overwrite):
+        # First creating a file
+        data_path = input('Please enter a path to the data files\nPress ENTER to use the home directory\n(a directory called cheops-pipe will be created inside the home directory): ')
+        ref_path = input('Please enter a path to the calibration files\nPress ENTER to use the home directory\n(a directory called cheops-pipe will be created inside the home directory): ')
+        if data_path == '':
+            data_path = os.path.expanduser('~') + '/cheops-pipe/Data'
+        if ref_path == '':
+            ref_path = os.path.expanduser('~') + '/cheops-pipe/Ref'
+        fconf = open(os.path.dirname(__file__) + '/conf.json', 'w')
+        fconf.write('{\n')
+        fconf.write('\t"data_root" : "' + data_path + '",\n')
+        fconf.write('\t"ref_lib_data" : "' + ref_path + '"\n')
+        fconf.write('}')
+        fconf.close()
+        # And loading it
+        conf_path = os.path.join(os.path.dirname(__file__), 'conf.json')
+
     with open(conf_path, 'r') as confstream:
         confparse = json.load(confstream)
     data_root_cfg = confparse.get("data_root")

--- a/pipe/config/pipeconf.py
+++ b/pipe/config/pipeconf.py
@@ -12,8 +12,8 @@ def get_conf_paths(overwrite=False):
     
     if (not os.path.isfile(conf_path))|(overwrite):
         # First creating a file
-        data_path = input('Please enter a path to the data files\nPress ENTER to use the home directory\n(a directory called cheops-pipe will be created inside the home directory): ')
-        ref_path = input('Please enter a path to the calibration files\nPress ENTER to use the home directory\n(a directory called cheops-pipe will be created inside the home directory): ')
+        data_path = input('Please enter a path to the data files\nThe default path is ~/cheops-pipe/Data (press ENTER to use this): ')
+        ref_path = input('Please enter a path to the calibration files\nThe default path is ~/cheops-pipe/Ref (press ENTER to use this): ')
         if data_path == '':
             data_path = os.path.expanduser('~') + '/cheops-pipe/Data'
         if ref_path == '':


### PR DESCRIPTION
This PR will address the path issues for `pipe`:
- After calling `pipe` for the first time after installation, it will ask for paths for data files and reference/calibration files
- Default paths are ~/cheops-pipe/Data and ~/cheops-pipe/Ref
- Please do the following if you want to change the paths again thereafter:
 ``from pipe.config import get_conf_paths``
and then do, ``get_conf_paths(overwrite=True)``. This will ask for paths again, from where you can change them.

Cheers,
Jayshil